### PR TITLE
Add build args to build command

### DIFF
--- a/lib/docker_remote/image.coffee
+++ b/lib/docker_remote/image.coffee
@@ -1,7 +1,7 @@
 Promise = require "bluebird"
 path    = require "path"
 
-module.exports = (DockerRemote) -> 
+module.exports = (DockerRemote) ->
 
   # Builds image from Dockerfile.
   #
@@ -31,7 +31,7 @@ module.exports = (DockerRemote) ->
     # Gets the sha of the app code.
     #
     # @return [Promise<String>] promise that resolves when command
-    #   finishes 
+    #   finishes
     #
     appSha: ->
       @spawnOut(
@@ -83,7 +83,7 @@ module.exports = (DockerRemote) ->
     # Runs `docker build` on the app code.
     #
     # @param [String] tag the tag of the release
-    # @return [Promise] promise that resolves when command finishes 
+    # @return [Promise] promise that resolves when command finishes
     #
     buildImage: (tag) ->
       @container.tag = tag
@@ -97,16 +97,21 @@ module.exports = (DockerRemote) ->
       app_dir   = path.resolve @container.dockerfile
       app_dir ||= ".tmp/#{@container.name}"
 
+      build_args = []
+      for key, value of @container.buildArgs || []
+        build_args.push "--build-arg #{key}=#{value}"
+
       """
       docker build \
         -t #{@container.repo}:#{@container.tag} \
+        #{build_args.join(" ")} \
         #{app_dir}
       """
 
     # Check `docker ps` for the existence of a container sha.
     #
     # @param [String] run_sha the sha of the container
-    # @return [Promise] promise that resolves when command finishes 
+    # @return [Promise] promise that resolves when command finishes
     #
     checkContainerSha: (run_sha) ->
       run_sha = run_sha.substring(0, 12)
@@ -139,7 +144,7 @@ module.exports = (DockerRemote) ->
 
     # Clone the app code into `.tmp`.
     #
-    # @return [Promise] promise that resolves when command finishes 
+    # @return [Promise] promise that resolves when command finishes
     #
     cloneApp: ->
       @spawnOut(@commands.clone_app)
@@ -170,7 +175,7 @@ module.exports = (DockerRemote) ->
 
     # Makes the directory to house the app code within `.tmp`.
     #
-    # @return [Promise] promise that resolves when command finishes 
+    # @return [Promise] promise that resolves when command finishes
     #
     mkdirApp: ->
       @spawnOut(@commands.mkdir_app)
@@ -178,14 +183,14 @@ module.exports = (DockerRemote) ->
     # Pushes the docker image to the registry.
     #
     # @param [Object] props shared properties from `build`
-    # @return [Promise] promise that resolves when command finishes 
+    # @return [Promise] promise that resolves when command finishes
     #
     pushImage: (props) ->
       if @container.push
         promise = @spawn(@pushImageCommand())
         for tag in @container.tags
           promise = promise.then => @spawn(@pushImageCommand(tag))
-      
+
       promise
 
     # Generates the `docker push` command.
@@ -198,7 +203,7 @@ module.exports = (DockerRemote) ->
 
     # Remove the app code in the `.tmp` directory.
     #
-    # @return [Promise] promise that resolves when command finishes 
+    # @return [Promise] promise that resolves when command finishes
     #
     rmrfApp: ->
       @spawnOut(@commands.rmrf_app)
@@ -206,7 +211,7 @@ module.exports = (DockerRemote) ->
     # Run the post build command.
     #
     # @param [Object] props shared properties from `build`
-    # @return [Promise] promise that resolves when command finishes 
+    # @return [Promise] promise that resolves when command finishes
     #
     runPostBuild: (props) ->
       container = new DockerRemote.Container(@container, "build")


### PR DESCRIPTION
Allows the build command to utilise the newly introduced `--build-args`.

_Warning:_ Required docker 1.9 or later.
